### PR TITLE
Use cover URLs for Bookety Top 100 books

### DIFF
--- a/_collections/_books/1984.md
+++ b/_collections/_books/1984.md
@@ -2,6 +2,7 @@
 title: 1984
 author: George Orwell
 bookety_rank: 36
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781784878979_a47bca33-934a-4de3-81ec-393a0ce15340.jpg?v=1761288261&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/A_Gentleman_in_Moscow.md
+++ b/_collections/_books/A_Gentleman_in_Moscow.md
@@ -2,6 +2,7 @@
 title: A Gentleman in Moscow
 author: Amor Towles
 bookety_rank: 60
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780099558781.jpg?v=1712279094&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/A_Little_Life.md
+++ b/_collections/_books/A_Little_Life.md
@@ -2,6 +2,7 @@
 title: A Little Life
 author: Hanya Yanagihara
 bookety_rank: 10
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781529077216.jpg?v=1707434365&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/A_Man_Called_Ove.md
+++ b/_collections/_books/A_Man_Called_Ove.md
@@ -2,6 +2,7 @@
 title: A Man Called Ove
 author: Fredrik Backman
 bookety_rank: 95
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781444775815.jpg?v=1670042413&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/A_Thousand_Splendid_Suns.md
+++ b/_collections/_books/A_Thousand_Splendid_Suns.md
@@ -2,6 +2,7 @@
 title: A Thousand Splendid Suns
 author: Khaled Hosseini
 bookety_rank: 45
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9780747593775.jpg?v=1679868055&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/All_Fours.md
+++ b/_collections/_books/All_Fours.md
@@ -2,6 +2,7 @@
 title: All Fours
 author: Miranda July
 bookety_rank: 93
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781838853457_1.jpg?v=1710286129&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/All_That_We_Know.md
+++ b/_collections/_books/All_That_We_Know.md
@@ -2,6 +2,7 @@
 title: All That We Know
 author: Shilo Kino
 bookety_rank: 61
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781869718237.jpg?v=1720505913&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/All_The_Light_We_Cannot_See.md
+++ b/_collections/_books/All_The_Light_We_Cannot_See.md
@@ -2,6 +2,7 @@
 title: All The Light We Cannot See
 author: Anthony Doerr
 bookety_rank: 31
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/AllTheLightWeCannotSee.jpg?v=1596774340&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/All_the_Colours_of_the_Dark.md
+++ b/_collections/_books/All_the_Colours_of_the_Dark.md
@@ -2,6 +2,7 @@
 title: All the Colours of the Dark
 author: Chris Whitaker
 bookety_rank: 83
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/original_9781398707672.jpg?v=1761281710&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/American_Dirt.md
+++ b/_collections/_books/American_Dirt.md
@@ -2,6 +2,7 @@
 title: American Dirt
 author: Jeanine Cummins
 bookety_rank: 59
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781472261403.jpg?v=1616570836&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Amma.md
+++ b/_collections/_books/Amma.md
@@ -2,6 +2,7 @@
 title: Amma
 author: Saraid de Silva
 bookety_rank: 53
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781869715403.jpg?v=1711058681&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Atmosphere.md
+++ b/_collections/_books/Atmosphere.md
@@ -2,6 +2,7 @@
 title: Atmosphere
 author: Taylor Jenkins Reid
 bookety_rank: 57
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781529152982.jpg?v=1736824225&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Au.md
+++ b/_collections/_books/Au.md
@@ -2,6 +2,7 @@
 title: Auē
 author: Becky Manawatu
 bookety_rank: 16
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780995111073.jpg?v=1761281315&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Babel.md
+++ b/_collections/_books/Babel.md
@@ -2,6 +2,7 @@
 title: Babel
 author: R.F. Kuang
 bookety_rank: 99
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/babel.jpg?v=1705612864&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Beartown.md
+++ b/_collections/_books/Beartown.md
@@ -2,6 +2,7 @@
 title: Beartown
 author: Fredrik Backman
 bookety_rank: 51
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781405930208.jpg?v=1686874830&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Before_the_Coffee_Gets_Cold.md
+++ b/_collections/_books/Before_the_Coffee_Gets_Cold.md
@@ -2,6 +2,7 @@
 title: Before the Coffee Gets Cold
 author: Toshikazu Kawaguchi
 bookety_rank: 80
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/BeforetheCoffeeGetsCold.jpg?v=1596939058&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Blue_Sisters.md
+++ b/_collections/_books/Blue_Sisters.md
@@ -2,6 +2,7 @@
 title: Blue Sisters
 author: Coco Mellors
 bookety_rank: 37
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/fdjsjndfds.jpg?v=1706127080&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Book_Lovers.md
+++ b/_collections/_books/Book_Lovers.md
@@ -2,6 +2,7 @@
 title: Book Lovers
 author: Emily Henry
 bookety_rank: 46
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9780241995341.jpg?v=1651045225&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Boy_Swallows_Universe.md
+++ b/_collections/_books/Boy_Swallows_Universe.md
@@ -2,6 +2,7 @@
 title: Boy Swallows Universe
 author: Trent Dalton
 bookety_rank: 24
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/BoySwallowsUniverse.jpg?v=1596780233&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Circe.md
+++ b/_collections/_books/Circe.md
@@ -13,6 +13,7 @@ read_status: Read
 layout: book
 book_cover_file: circe.jpeg
 bookety_rank: 49
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781408890042.jpg?v=1628500443&width=480
 ---
 
 

--- a/_collections/_books/Cleopatra_and_Frankenstein.md
+++ b/_collections/_books/Cleopatra_and_Frankenstein.md
@@ -2,6 +2,7 @@
 title: Cleopatra and Frankenstein
 author: Coco Mellors
 bookety_rank: 94
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/image_e28d671c-282b-43da-bfb8-903cfd6eab5f.jpg?v=1673511999&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Crying_in_H_Mart.md
+++ b/_collections/_books/Crying_in_H_Mart.md
@@ -2,6 +2,7 @@
 title: Crying in H Mart
 author: Michelle Zauner
 bookety_rank: 90
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781529033793.jpg?v=1676587782&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Daisy_Jones_and_The_Six.md
+++ b/_collections/_books/Daisy_Jones_and_The_Six.md
@@ -2,6 +2,7 @@
 title: Daisy Jones and The Six
 author: Taylor Jenkins Reid
 bookety_rank: 22
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781787462144_1.jpg?v=1724629625&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Demon_Copperhead.md
+++ b/_collections/_books/Demon_Copperhead.md
@@ -2,6 +2,7 @@
 title: Demon Copperhead
 author: Barbara Kingsolver
 bookety_rank: 6
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780571376483.jpg?v=1683504508&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Educated.md
+++ b/_collections/_books/Educated.md
@@ -2,6 +2,7 @@
 title: Educated
 author: Tara Westover
 bookety_rank: 13
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780099511021_1.jpg?v=1723073215&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Everything_I_Know_About_Love.md
+++ b/_collections/_books/Everything_I_Know_About_Love.md
@@ -2,6 +2,7 @@
 title: Everything I Know About Love
 author: Dolly Alderton
 bookety_rank: 17
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/2714d009-dbae-4879-a6ae-5c0e69745db8.jpg?v=1597041393&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Everything_is_Beautiful_and_Everything_Hurts.md
+++ b/_collections/_books/Everything_is_Beautiful_and_Everything_Hurts.md
@@ -2,6 +2,7 @@
 title: Everything is Beautiful and Everything Hurts
 author: Josie Shapiro
 bookety_rank: 88
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781991006448.jpg?v=1685002290&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Fourth_Wing.md
+++ b/_collections/_books/Fourth_Wing.md
@@ -2,6 +2,7 @@
 title: Fourth Wing
 author: Rebecca Yarros
 bookety_rank: 3
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780349437019.jpg?v=1712014857&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Funny_Story.md
+++ b/_collections/_books/Funny_Story.md
@@ -2,6 +2,7 @@
 title: Funny Story
 author: Emily Henry
 bookety_rank: 56
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780241998175.jpg?v=1741042941&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Girl_Woman_Other.md
+++ b/_collections/_books/Girl_Woman_Other.md
@@ -2,6 +2,7 @@
 title: Girl, Woman, Other
 author: Bernardine Evaristo
 bookety_rank: 96
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/86cae6c1-b185-4a2b-8bbe-6c961fc3bbae.jpg?v=1597032451&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Good_Material.md
+++ b/_collections/_books/Good_Material.md
@@ -2,6 +2,7 @@
 title: Good Material
 author: Dolly Alderton
 bookety_rank: 50
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780241993163_1.jpg?v=1723073257&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Great_Big_Beautiful_Life.md
+++ b/_collections/_books/Great_Big_Beautiful_Life.md
@@ -2,6 +2,7 @@
 title: Great Big Beautiful Life
 author: Emily Henry
 bookety_rank: 75
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780241740613.jpg?v=1736824225&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Greta_and_Valdin.md
+++ b/_collections/_books/Greta_and_Valdin.md
@@ -2,6 +2,7 @@
 title: Greta and Valdin
 author: Rebecca K Reilly
 bookety_rank: 52
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781776922109_Greta_and_Valdin_B_Format_RGB__49026_1.webp?v=1726018964&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Hello_Beautiful.md
+++ b/_collections/_books/Hello_Beautiful.md
@@ -2,6 +2,7 @@
 title: Hello Beautiful
 author: Ann Napolitano
 bookety_rank: 40
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780241998496_1.jpg?v=1722212563&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/I_Am_Pilgrim.md
+++ b/_collections/_books/I_Am_Pilgrim.md
@@ -2,6 +2,7 @@
 title: I Am Pilgrim
 author: Terry Hayes
 bookety_rank: 74
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9780552160964.jpg?v=1665961362&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/I_Who_Have_Never_Known_Men.md
+++ b/_collections/_books/I_Who_Have_Never_Known_Men.md
@@ -2,6 +2,7 @@
 title: I Who Have Never Known Men
 author: Jacqueline Harpman
 bookety_rank: 21
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781473570801.jpg?v=1684998629&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Im_Glad_My_Mom_Died.md
+++ b/_collections/_books/Im_Glad_My_Mom_Died.md
@@ -2,6 +2,7 @@
 title: I'm Glad My Mom Died
 author: Jennette McCurdy
 bookety_rank: 47
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/im-glad-my-mom-died-9781982185824_xlg.jpg?v=1660459551&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/In_Memoriam.md
+++ b/_collections/_books/In_Memoriam.md
@@ -2,6 +2,7 @@
 title: In Memoriam
 author: Alice Winn
 bookety_rank: 71
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780241567838_1.jpg?v=1721771733&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Intermezzo.md
+++ b/_collections/_books/Intermezzo.md
@@ -2,6 +2,7 @@
 title: Intermezzo
 author: Sally Rooney
 bookety_rank: 63
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780571365487_b821b137-2a63-45c9-93ca-90a17ad22616.jpg?v=1761290122&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/James.md
+++ b/_collections/_books/James.md
@@ -2,6 +2,7 @@
 title: James
 author: Percival Everett
 bookety_rank: 91
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781035031269.jpg?v=1758071940&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Jane_Eyre.md
+++ b/_collections/_books/Jane_Eyre.md
@@ -2,6 +2,7 @@
 title: Jane Eyre
 author: Charlotte Brontë
 bookety_rank: 58
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781784870737.jpg?v=1761290158&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Just_Kids.md
+++ b/_collections/_books/Just_Kids.md
@@ -2,6 +2,7 @@
 title: Just Kids
 author: Patti Smith
 bookety_rank: 79
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9780747568766.jpg?v=1679011929&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Know_My_Name.md
+++ b/_collections/_books/Know_My_Name.md
@@ -2,6 +2,7 @@
 title: Know My Name
 author: Chanel Miller
 bookety_rank: 44
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/f41c645e-3352-4b63-9345-ba516bb173f5.jpg?v=1597088979&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Lessons_in_Chemistry.md
+++ b/_collections/_books/Lessons_in_Chemistry.md
@@ -2,6 +2,7 @@
 title: Lessons in Chemistry
 author: Elizabeth Zott
 bookety_rank: 7
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781804990926.jpg?v=1679345735&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Little_Women.md
+++ b/_collections/_books/Little_Women.md
@@ -2,6 +2,7 @@
 title: Little Women
 author: Louisa May Alcott
 bookety_rank: 29
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/d41536ac-8d0f-4203-a530-5c613803dd63.jpg?v=1597044648&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Lola_in_the_Mirror.md
+++ b/_collections/_books/Lola_in_the_Mirror.md
@@ -2,6 +2,7 @@
 title: Lola in the Mirror
 author: Trent Dalton
 bookety_rank: 42
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/y648_24.jpg?v=1758498091&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Make_It_Make_Sense.md
+++ b/_collections/_books/Make_It_Make_Sense.md
@@ -2,6 +2,7 @@
 title: Make It Make Sense
 author: Bel Hawkins & Lucy Blakiston
 bookety_rank: 18
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780733651298.jpg?v=1717641286&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/My_Brilliant_Friend.md
+++ b/_collections/_books/My_Brilliant_Friend.md
@@ -2,6 +2,7 @@
 title: My Brilliant Friend
 author: Elena Ferrante
 bookety_rank: 89
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/MyBrilliantFriend.jpg?v=1596953842&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/My_Year_of_Rest_and_Relaxation.md
+++ b/_collections/_books/My_Year_of_Rest_and_Relaxation.md
@@ -2,6 +2,7 @@
 title: My Year of Rest and Relaxation
 author: Ottessa Moshfegh
 bookety_rank: 72
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/6344fda5-2b88-48ad-b99d-aae8e4972801.jpg?v=1597092020&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Normal_People.md
+++ b/_collections/_books/Normal_People.md
@@ -2,6 +2,7 @@
 title: Normal People
 author: Sally Rooney
 bookety_rank: 5
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780571334650_3299b8fd-fdf5-4b27-b58e-fefbeeadbf85.jpg?v=1761287654&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/One_Day.md
+++ b/_collections/_books/One_Day.md
@@ -2,6 +2,7 @@
 title: One Day
 author: David Nicholls
 bookety_rank: 65
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780340896983.jpg?v=1710111648&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Pachinko.md
+++ b/_collections/_books/Pachinko.md
@@ -2,6 +2,7 @@
 title: Pachinko
 author: Min Jin Lee
 bookety_rank: 27
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781838930509.jpg?v=1718252716&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Pet.md
+++ b/_collections/_books/Pet.md
@@ -2,6 +2,7 @@
 title: Pet
 author: Catherine Chidgey
 bookety_rank: 76
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781776922253_Pet_B_format__82588.jpg?v=1736902279&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Piranesi.md
+++ b/_collections/_books/Piranesi.md
@@ -2,6 +2,7 @@
 title: Piranesi
 author: Susanna Clarke
 bookety_rank: 77
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781526622433.jpg?v=1631127440&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Pride_Prejudice.md
+++ b/_collections/_books/Pride_Prejudice.md
@@ -2,6 +2,7 @@
 title: Pride & Prejudice
 author: Jane Austen
 bookety_rank: 20
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781035007790.jpg?v=1700779101&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Rebecca.md
+++ b/_collections/_books/Rebecca.md
@@ -2,6 +2,7 @@
 title: Rebecca
 author: Daphne Du Maurier
 bookety_rank: 64
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/rebecca-2.jpg?v=1761288568&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Remarkably_Bright_Creatures.md
+++ b/_collections/_books/Remarkably_Bright_Creatures.md
@@ -2,6 +2,7 @@
 title: Remarkably Bright Creatures
 author: Shelby Van Pelt
 bookety_rank: 12
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/original_temp_img_2.jpg?v=1761287785&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Shark_Heart.md
+++ b/_collections/_books/Shark_Heart.md
@@ -2,6 +2,7 @@
 title: Shark Heart
 author: Emily Habeck
 bookety_rank: 35
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781529432237.jpg?v=1719792161&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Small_Things_Like_These.md
+++ b/_collections/_books/Small_Things_Like_These.md
@@ -2,6 +2,7 @@
 title: Small Things Like These
 author: Claire Keegan
 bookety_rank: 86
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9780571368709.jpg?v=1668666159&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Sorrow_and_Bliss.md
+++ b/_collections/_books/Sorrow_and_Bliss.md
@@ -2,6 +2,7 @@
 title: Sorrow and Bliss
 author: Meg Mason
 bookety_rank: 30
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/sorrowandbliss.jpg?v=1706822669&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Station_Eleven.md
+++ b/_collections/_books/Station_Eleven.md
@@ -2,6 +2,7 @@
 title: Station Eleven
 author: Emily St. John Mandel
 bookety_rank: 66
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781447268970.jpg?v=1761286134&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Still_Life.md
+++ b/_collections/_books/Still_Life.md
@@ -2,6 +2,7 @@
 title: Still Life
 author: Sarah Winman
 bookety_rank: 73
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/y648_3.jpg?v=1761282318&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Axemans_Carnival.md
+++ b/_collections/_books/The_Axemans_Carnival.md
@@ -2,6 +2,7 @@
 title: The Axeman's Carnival
 author: Catherine Chidgey
 bookety_rank: 43
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781776922260_The_Axemans_Carnival_B_format__26770.jpg?v=1736902048&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Bee_Sting.md
+++ b/_collections/_books/The_Bee_Sting.md
@@ -2,6 +2,7 @@
 title: The Bee Sting
 author: Paul Murray
 bookety_rank: 98
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780241984406.jpg?v=1715294601&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Bell_Jar.md
+++ b/_collections/_books/The_Bell_Jar.md
@@ -2,6 +2,7 @@
 title: The Bell Jar
 author: Sylvia Plath
 bookety_rank: 100
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/TheBellJar.jpg?v=1597021690&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Book_Thief.md
+++ b/_collections/_books/The_Book_Thief.md
@@ -2,6 +2,7 @@
 title: The Book Thief
 author: Markus Zusak
 bookety_rank: 28
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781760783693.jpg?v=1674002022&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Book_of_Guilt.md
+++ b/_collections/_books/The_Book_of_Guilt.md
@@ -2,6 +2,7 @@
 title: The Book of Guilt
 author: Catherine Chidgey
 bookety_rank: 78
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781776922246_The_Book_of_Guilt__10108_1.jpg?v=1736824352&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Bookseller_at_the_End_of_the_World.md
+++ b/_collections/_books/The_Bookseller_at_the_End_of_the_World.md
@@ -2,6 +2,7 @@
 title: The Bookseller at the End of the World
 author: Ruth Shaw
 bookety_rank: 87
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781988547756_1.jpg?v=1649142878&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Elements.md
+++ b/_collections/_books/The_Elements.md
@@ -2,6 +2,7 @@
 title: The Elements
 author: John Boyne
 bookety_rank: 41
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780857528889.jpg?v=1752466204&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_God_of_The_Woods.md
+++ b/_collections/_books/The_God_of_The_Woods.md
@@ -2,6 +2,7 @@
 title: The God of The Woods
 author: Liz Moore
 bookety_rank: 32
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780008663803.jpg?v=1720138846&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Goldfinch.md
+++ b/_collections/_books/The_Goldfinch.md
@@ -2,6 +2,7 @@
 title: The Goldfinch
 author: Donna Tartt
 bookety_rank: 70
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780349139630.jpg?v=1700778890&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Great_Alone.md
+++ b/_collections/_books/The_Great_Alone.md
@@ -2,6 +2,7 @@
 title: The Great Alone
 author: Kristin Hannah
 bookety_rank: 23
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781760558574.jpg?v=1719282777&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Handmaids_Tale.md
+++ b/_collections/_books/The_Handmaids_Tale.md
@@ -2,6 +2,7 @@
 title: The Handmaid's Tale
 author: Margaret Atwood
 bookety_rank: 26
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9780099740919.jpg?v=1616129176&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Hearts_Invisible_Furies.md
+++ b/_collections/_books/The_Hearts_Invisible_Furies.md
@@ -2,6 +2,7 @@
 title: The Heart's Invisible Furies
 author: John Boyne
 bookety_rank: 25
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781784161002_54a07ce5-d2fe-4692-9d28-21662f9db4ec.jpg?v=1761285794&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_House_in_the_Cerulean_Sea.md
+++ b/_collections/_books/The_House_in_the_Cerulean_Sea.md
@@ -2,6 +2,7 @@
 title: The House in the Cerulean Sea
 author: TJ Klune
 bookety_rank: 54
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781529087949.jpg?v=1660353753&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Hunger_Games.md
+++ b/_collections/_books/The_Hunger_Games.md
@@ -2,6 +2,7 @@
 title: The Hunger Games
 author: Suzanne Collins
 bookety_rank: 11
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781760265304.jpg?v=1761281509&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Invisible_Life_of_Addie_LaRue.md
+++ b/_collections/_books/The_Invisible_Life_of_Addie_LaRue.md
@@ -2,6 +2,7 @@
 title: The Invisible Life of Addie LaRue
 author: V.E. Schwab
 bookety_rank: 34
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781789095593.jpg?v=1611035666&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Island_of_Missing_Trees.md
+++ b/_collections/_books/The_Island_of_Missing_Trees.md
@@ -2,6 +2,7 @@
 title: The Island of Missing Trees
 author: Elif Shafak
 bookety_rank: 92
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780241988725.jpg?v=1656904102&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Kite_Runner.md
+++ b/_collections/_books/The_Kite_Runner.md
@@ -2,6 +2,7 @@
 title: The Kite Runner
 author: Khaled Hosseini
 bookety_rank: 39
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781526604743.jpg?v=1674509061&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Midnight_Library.md
+++ b/_collections/_books/The_Midnight_Library.md
@@ -2,6 +2,7 @@
 title: The Midnight Library
 author: Matt Haig
 bookety_rank: 48
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781786892737_1.jpg?v=1679867507&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Nightingale.md
+++ b/_collections/_books/The_Nightingale.md
@@ -2,6 +2,7 @@
 title: The Nightingale
 author: Kristin Hannah
 bookety_rank: 4
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781509848621.jpg?v=1700166475&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Poisonwood_Bible.md
+++ b/_collections/_books/The_Poisonwood_Bible.md
@@ -2,6 +2,7 @@
 title: The Poisonwood Bible
 author: Barbara Kingsolver
 bookety_rank: 68
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/original_9780571339792_a17eca1c-96e6-49d0-a809-35b17e773b1e.jpg?v=1761283664&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Rachel_Incident.md
+++ b/_collections/_books/The_Rachel_Incident.md
@@ -2,6 +2,7 @@
 title: The Rachel Incident
 author: Caroline O'Donoghue
 bookety_rank: 85
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780349013565.jpg?v=1718061921&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Safekeep.md
+++ b/_collections/_books/The_Safekeep.md
@@ -2,6 +2,7 @@
 title: The Safekeep
 author: Yael van der Wouden
 bookety_rank: 97
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780241999776.jpg?v=1751942128&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Secret_History.md
+++ b/_collections/_books/The_Secret_History.md
@@ -13,4 +13,5 @@ read_status: Read
 layout: book
 book_cover_file: the_secret_history.jpg
 bookety_rank: 14
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9780140167771.jpg?v=1674503199&width=480
 ---

--- a/_collections/_books/The_Seven_Husbands_of_Evelyn_Hugo.md
+++ b/_collections/_books/The_Seven_Husbands_of_Evelyn_Hugo.md
@@ -13,4 +13,5 @@ read_status: Read
 layout: book
 book_cover_file: the_seven_husbands_of_evelyn_hugo.jpg
 bookety_rank: 2
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/aa630409-5c0d-4082-b2da-397a650bd352.jpg?v=1618807661&width=480
 ---

--- a/_collections/_books/The_Silent_Patient.md
+++ b/_collections/_books/The_Silent_Patient.md
@@ -2,6 +2,7 @@
 title: The Silent Patient
 author: Alex Michaelides
 bookety_rank: 82
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781409181637.jpg?v=1672812963&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Song_of_Achilles.md
+++ b/_collections/_books/The_Song_of_Achilles.md
@@ -2,6 +2,7 @@
 title: The Song of Achilles
 author: Madeline Miller
 bookety_rank: 9
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781408891384.jpg?v=1643776507&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Thursday_Murder_Club.md
+++ b/_collections/_books/The_Thursday_Murder_Club.md
@@ -13,4 +13,5 @@ read_status: Read
 layout: book
 book_cover_file: the_thursday_murder_club.jpg
 bookety_rank: 55
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9780241988268.jpg?v=1638159485&width=480
 ---

--- a/_collections/_books/The_Wedding_People.md
+++ b/_collections/_books/The_Wedding_People.md
@@ -2,6 +2,7 @@
 title: The Wedding People
 author: Alison Espach
 bookety_rank: 38
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781399622745.jpg?v=1733197367&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/The_Women.md
+++ b/_collections/_books/The_Women.md
@@ -2,6 +2,7 @@
 title: The Women
 author: Kristin Hannah
 bookety_rank: 8
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781035005697.jpg?v=1744769424&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/There_Are_Rivers_in_the_Sky.md
+++ b/_collections/_books/There_Are_Rivers_in_the_Sky.md
@@ -2,6 +2,7 @@
 title: There Are Rivers in the Sky
 author: Elif Shafak
 bookety_rank: 67
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9780241435021_4.jpg?v=1726610767&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Throne_of_Glass.md
+++ b/_collections/_books/Throne_of_Glass.md
@@ -2,6 +2,7 @@
 title: Throne of Glass
 author: Sarah J. Maas
 bookety_rank: 33
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781526660923.jpg?v=1676338180&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/To_Kill_A_Mockingbird.md
+++ b/_collections/_books/To_Kill_A_Mockingbird.md
@@ -2,6 +2,7 @@
 title: To Kill A Mockingbird
 author: Harper Lee
 bookety_rank: 19
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781804958728.jpg?v=1761283817&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Tom_Lake.md
+++ b/_collections/_books/Tom_Lake.md
@@ -2,6 +2,7 @@
 title: Tom Lake
 author: Ann Patchett
 bookety_rank: 81
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781526676733.jpg?v=1715732612&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Tomorrow_and_Tomorrow_and_Tomorrow.md
+++ b/_collections/_books/Tomorrow_and_Tomorrow_and_Tomorrow.md
@@ -2,6 +2,7 @@
 title: Tomorrow, and Tomorrow, and Tomorrow
 author: Gabrielle Zevin
 bookety_rank: 1
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781529115543.jpg?v=1688082470&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Verity.md
+++ b/_collections/_books/Verity.md
@@ -2,6 +2,7 @@
 title: Verity
 author: Colleen Hoover
 bookety_rank: 69
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/9781408726600.jpg?v=1646959526&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Where_the_Crawdads_Sing.md
+++ b/_collections/_books/Where_the_Crawdads_Sing.md
@@ -2,6 +2,7 @@
 title: Where the Crawdads Sing
 author: Delia Owens
 bookety_rank: 15
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/d732902a-09e6-46cc-b412-b7671f9fb1a7.jpg?v=1597225050&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Wild_Dark_Shore.md
+++ b/_collections/_books/Wild_Dark_Shore.md
@@ -2,6 +2,7 @@
 title: Wild Dark Shore
 author: Charlotte McConaghy
 bookety_rank: 62
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/files/9781761620003.jpg?v=1736824225&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_collections/_books/Yellowface.md
+++ b/_collections/_books/Yellowface.md
@@ -2,6 +2,7 @@
 title: Yellowface
 author: Rebecca F. Kuang
 bookety_rank: 84
+book_cover_url: https://www.booketybookbooks.co.nz/cdn/shop/products/y648_4_26528f6d-3608-4e83-b7dc-f03aab6b92d8.jpg?v=1677458097&width=480
 is_audiobook: false
 read_status: Not Started
 layout: book

--- a/_includes/bookety_list.html
+++ b/_includes/bookety_list.html
@@ -17,7 +17,9 @@
                 <a href="{{ post.url | relative_url }}" class="book-card">
                     <div class="book-rank">#{{ post.bookety_rank }}</div>
                     <div class="book-cover-wrapper{% if post.is_audiobook %} audiobook{% endif %}">
-                        {%- if post.book_cover_file -%}
+                        {%- if post.book_cover_url -%}
+                        <img src="{{ post.book_cover_url }}" alt="{{ post.title }}" loading="lazy">
+                        {%- elsif post.book_cover_file -%}
                         <img src="{{ site.baseurl }}/assets/bookcovers/{{ post.book_cover_file }}" alt="{{ post.title }}" loading="lazy">
                         {%- else -%}
                         <div class="no-cover">
@@ -47,7 +49,9 @@
                 <a href="{{ post.url | relative_url }}" class="book-card">
                     <div class="book-rank">#{{ post.bookety_rank }}</div>
                     <div class="book-cover-wrapper{% if post.is_audiobook %} audiobook{% endif %}">
-                        {%- if post.book_cover_file -%}
+                        {%- if post.book_cover_url -%}
+                        <img src="{{ post.book_cover_url }}" alt="{{ post.title }}" loading="lazy">
+                        {%- elsif post.book_cover_file -%}
                         <img src="{{ site.baseurl }}/assets/bookcovers/{{ post.book_cover_file }}" alt="{{ post.title }}" loading="lazy">
                         {%- else -%}
                         <div class="no-cover">
@@ -77,7 +81,9 @@
                 <a href="{{ post.url | relative_url }}" class="book-card">
                     <div class="book-rank">#{{ post.bookety_rank }}</div>
                     <div class="book-cover-wrapper{% if post.is_audiobook %} audiobook{% endif %}">
-                        {%- if post.book_cover_file -%}
+                        {%- if post.book_cover_url -%}
+                        <img src="{{ post.book_cover_url }}" alt="{{ post.title }}" loading="lazy">
+                        {%- elsif post.book_cover_file -%}
                         <img src="{{ site.baseurl }}/assets/bookcovers/{{ post.book_cover_file }}" alt="{{ post.title }}" loading="lazy">
                         {%- else -%}
                         <div class="no-cover">


### PR DESCRIPTION
- Added book_cover_url field to all 100 Bookety books
- Updated bookety_list.html to use URLs instead of local files
- Cover images now load directly from Bookety website
- Fallback to local files if URL not available