### PR TITLE
Update reading list UI with dark, elegant design

### DIFF
--- a/_sass/no-style-please.scss
+++ b/_sass/no-style-please.scss
@@ -15,6 +15,15 @@
     .book-cover img {
         filter: invert(0);
     }
+
+    // Don't invert the reading list page (it has its own dark styling)
+    .reading-list-page {
+        filter: invert(0);
+
+        img {
+            filter: invert(0);
+        }
+    }
 }
 
 body[a="dark"] {

--- a/_sass/reading-list-style.scss
+++ b/_sass/reading-list-style.scss
@@ -1,35 +1,50 @@
 // -------------- READING LIST PAGE STYLING -------------- //
 
+// Override the narrow width for reading list pages
+.page-content .w:has(.reading-list-page) {
+    max-width: 1200px;
+}
+
 .reading-list-page {
+    background-color: #1a1a1a;
+    min-height: 100vh;
+    padding: 2rem 0;
+
     // Header
     h1 {
-        color: #667eea;
-        margin-bottom: 2rem;
+        color: #e0e0e0;
+        margin-bottom: 3rem;
         font-size: 2.5rem;
+        font-weight: 300;
+        letter-spacing: 0.5px;
     }
 
     // Section headers (Reading, Read, etc.)
     > ul > li > h3 {
-        color: #667eea;
-        font-size: 1.8rem;
-        margin: 2rem 0 1.5rem 0;
-        padding-bottom: 0.5rem;
-        border-bottom: 2px solid rgba(102, 126, 234, 0.3);
+        color: #b0b0b0;
+        font-size: 1.5rem;
+        font-weight: 400;
+        margin: 3rem 0 2rem 0;
+        padding-bottom: 0.75rem;
+        border-bottom: 1px solid rgba(176, 176, 176, 0.2);
+        letter-spacing: 0.3px;
     }
 
     // Year headers
     h5 {
-        color: #764ba2;
-        font-size: 1.3rem;
-        margin: 2rem 0 1rem 0;
+        color: #909090;
+        font-size: 1.1rem;
+        font-weight: 400;
+        margin: 2.5rem 0 1.5rem 0;
+        letter-spacing: 0.2px;
 
         a {
-            color: #764ba2;
+            color: #909090;
             text-decoration: none;
             transition: color 0.3s ease;
 
             &:hover {
-                color: #667eea;
+                color: #c0c0c0;
             }
         }
     }
@@ -43,9 +58,9 @@
             list-style: none;
             padding: 0;
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-            gap: 1.5rem;
-            margin-bottom: 2rem;
+            grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+            gap: 2rem;
+            margin-bottom: 3rem;
 
             > li {
                 display: flex;
@@ -59,16 +74,17 @@
         display: flex;
         flex-direction: column;
         text-decoration: none;
-        transition: transform 0.3s ease, box-shadow 0.3s ease;
-        border-radius: 8px;
+        transition: transform 0.3s ease, opacity 0.3s ease;
+        border-radius: 4px;
         overflow: hidden;
         width: 100%;
 
         &:hover {
-            transform: translateY(-5px);
+            transform: translateY(-8px) scale(1.02);
+            opacity: 0.9;
 
             .book-cover-wrapper {
-                box-shadow: 0 8px 20px rgba(102, 126, 234, 0.3);
+                box-shadow: 0 12px 30px rgba(0, 0, 0, 0.6);
             }
         }
 
@@ -76,11 +92,11 @@
             position: relative;
             width: 100%;
             padding-bottom: 150%; // 2:3 aspect ratio (default for books)
-            background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
-            border-radius: 8px;
+            background: #2a2a2a;
+            border-radius: 4px;
             overflow: hidden;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-            transition: box-shadow 0.3s ease;
+            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.5);
+            transition: box-shadow 0.3s ease, transform 0.3s ease;
 
             &.audiobook {
                 padding-bottom: 100%; // 1:1 aspect ratio for audiobooks
@@ -108,23 +124,23 @@
                 padding: 1rem;
                 text-align: center;
                 background: linear-gradient(135deg,
-                    rgba(102, 126, 234, 0.1) 0%,
-                    rgba(118, 75, 162, 0.1) 100%);
-                border: 2px dashed rgba(102, 126, 234, 0.3);
+                    rgba(60, 60, 60, 0.8) 0%,
+                    rgba(40, 40, 40, 0.8) 100%);
+                border: 1px solid rgba(100, 100, 100, 0.3);
                 box-sizing: border-box;
 
                 .book-icon {
                     font-size: 2.5rem;
                     margin-bottom: 0.75rem;
-                    opacity: 0.6;
-                    filter: grayscale(0.3);
+                    opacity: 0.4;
+                    filter: grayscale(0.8);
                     flex-shrink: 0;
                 }
 
                 .book-title-placeholder {
                     font-size: 0.85rem;
-                    color: #4a5568;
-                    font-weight: 600;
+                    color: #909090;
+                    font-weight: 400;
                     line-height: 1.4;
                     overflow: hidden;
                     display: -webkit-box;
@@ -137,25 +153,27 @@
         }
 
         .book-info {
-            padding: 0.75rem 0;
+            padding: 1rem 0 0.5rem 0;
 
             .book-title {
-                font-weight: 600;
-                color: #2d3748;
+                font-weight: 500;
+                color: #d0d0d0;
                 font-size: 0.9rem;
-                margin-bottom: 0.25rem;
+                margin-bottom: 0.3rem;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
-                line-height: 1.3;
+                line-height: 1.4;
+                letter-spacing: 0.2px;
             }
 
             .book-author {
                 font-size: 0.85rem;
-                color: #718096;
+                color: #909090;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
+                letter-spacing: 0.1px;
             }
         }
     }
@@ -163,40 +181,54 @@
 
 // Back link styling for reading list
 .reading-list-page .back-link-wrapper {
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
 
     a {
         display: inline-block;
-        color: #667eea;
+        color: #909090;
         text-decoration: none;
-        font-weight: 600;
+        font-weight: 400;
         padding: 0.25rem 0.5rem;
         transition: all 0.3s ease;
+        font-size: 0.95rem;
+        letter-spacing: 0.2px;
 
         &:hover {
-            opacity: 0.7;
+            color: #c0c0c0;
         }
     }
 }
 
 // Responsive design
-@media (max-width: 640px) {
+@media (max-width: 768px) {
     .reading-list-page {
+        padding: 1.5rem 0;
+
         h1 {
             font-size: 2rem;
+            margin-bottom: 2rem;
         }
 
         > ul > li > h3 {
-            font-size: 1.5rem;
+            font-size: 1.3rem;
+            margin: 2rem 0 1.5rem 0;
+        }
+
+        h5 {
+            font-size: 1rem;
+            margin: 2rem 0 1rem 0;
         }
 
         > ul > li > ul {
-            grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
-            gap: 1rem;
+            grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+            gap: 1.5rem;
+            margin-bottom: 2rem;
         }
 
         .book-card {
             .book-info {
+                padding: 0.75rem 0 0.25rem 0;
+
                 .book-title {
                     font-size: 0.85rem;
                 }
@@ -209,121 +241,23 @@
     }
 }
 
-// Dark mode
-body[a="dark"] .reading-list-page {
-    h1 {
-        color: #a78bfa;
-    }
+// Additional styling for bookety challenge link
+.reading-list-page .bookety-challenge-link {
+    background: rgba(40, 40, 40, 0.6) !important;
+    border-left-color: #606060 !important;
+    border-radius: 6px !important;
 
-    > ul > li > h3 {
-        color: #a78bfa;
-        border-bottom-color: rgba(167, 139, 250, 0.3);
-    }
-
-    h5 {
-        color: #c4b5fd;
-
-        a {
-            color: #c4b5fd;
-
-            &:hover {
-                color: #a78bfa;
-            }
+    p {
+        strong {
+            color: #c0c0c0;
         }
     }
 
-    .book-card {
-        .book-cover-wrapper {
-            background: linear-gradient(135deg, #2d3748 0%, #1a202c 100%);
+    a {
+        color: #909090 !important;
 
-            .no-cover {
-                background: linear-gradient(135deg,
-                    rgba(167, 139, 250, 0.15) 0%,
-                    rgba(196, 113, 237, 0.15) 100%);
-                border-color: rgba(167, 139, 250, 0.3);
-
-                .book-title-placeholder {
-                    color: #cbd5e0;
-                }
-            }
-        }
-
-        &:hover .book-cover-wrapper {
-            box-shadow: 0 8px 20px rgba(167, 139, 250, 0.3);
-        }
-
-        .book-info {
-            .book-title {
-                color: #e2e8f0;
-            }
-
-            .book-author {
-                color: #a0aec0;
-            }
-        }
-    }
-
-    .back-link-wrapper a {
-        color: #a78bfa;
-    }
-}
-
-@media (prefers-color-scheme: dark) {
-    body[a="auto"] .reading-list-page {
-        h1 {
-            color: #a78bfa;
-        }
-
-        > ul > li > h3 {
-            color: #a78bfa;
-            border-bottom-color: rgba(167, 139, 250, 0.3);
-        }
-
-        h5 {
-            color: #c4b5fd;
-
-            a {
-                color: #c4b5fd;
-
-                &:hover {
-                    color: #a78bfa;
-                }
-            }
-        }
-
-        .book-card {
-            .book-cover-wrapper {
-                background: linear-gradient(135deg, #2d3748 0%, #1a202c 100%);
-
-                .no-cover {
-                    background: linear-gradient(135deg,
-                        rgba(167, 139, 250, 0.15) 0%,
-                        rgba(196, 113, 237, 0.15) 100%);
-                    border-color: rgba(167, 139, 250, 0.3);
-
-                    .book-title-placeholder {
-                        color: #cbd5e0;
-                    }
-                }
-            }
-
-            &:hover .book-cover-wrapper {
-                box-shadow: 0 8px 20px rgba(167, 139, 250, 0.3);
-            }
-
-            .book-info {
-                .book-title {
-                    color: #e2e8f0;
-                }
-
-                .book-author {
-                    color: #a0aec0;
-                }
-            }
-        }
-
-        .back-link-wrapper a {
-            color: #a78bfa;
+        &:hover {
+            color: #c0c0c0 !important;
         }
     }
 }


### PR DESCRIPTION
- Implement dark background (#1a1a1a) for reading list pages
- Increase grid layout from 130px to 160px minimum width for better book display
- Update color scheme: headers, year links, and book info text in muted gray tones
- Enhance hover effects with improved scale and shadow animations
- Increase spacing and margins for better visual hierarchy
- Widen page container from 640px to 1200px for optimal grid layout
- Exclude reading-list-page from global dark mode filter inversion
- Update bookety challenge link styling to match dark theme
- Improve responsive design for mobile devices